### PR TITLE
Add support for android support library 23.1.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.1"
+    compileSdkVersion projectCompileSdkVersion
+    buildToolsVersion projectBuildToolsVersion
 
     defaultConfig {
         applicationId "com.rey.material.demo"
-        minSdkVersion 9
-        targetSdkVersion 21
+        minSdkVersion projectMinSdkVersion
+        targetSdkVersion projectCompileSdkVersion
         versionCode 5
         versionName "0.0.5"
     }
@@ -32,8 +32,8 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:22.2.0'
-    compile 'com.android.support:cardview-v7:22.2.0'
+    compile 'com.android.support:appcompat-v7:23.1.1'
+    compile 'com.android.support:cardview-v7:23.1.1'
     compile 'com.squareup.picasso:picasso:2.5.0'
     compile 'com.squareup.leakcanary:leakcanary-android:1.3.1'
     compile project(':lib')

--- a/build.gradle
+++ b/build.gradle
@@ -19,4 +19,9 @@ allprojects {
     repositories {
         jcenter()
     }
+    ext {
+      projectBuildToolsVersion = BUILD_TOOLS_VERSION
+      projectMinSdkVersion = Integer.parseInt(MIN_SDK_VERSION)
+      projectCompileSdkVersion = Integer.parseInt(COMPILE_SDK_VERSION)
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,6 +21,10 @@ VERSION_NAME=1.2.1
 VERSION_CODE=7
 GROUP=com.github.rey5137
 
+MIN_SDK_VERSION=9
+COMPILE_SDK_VERSION=23
+BUILD_TOOLS_VERSION=23.0.2
+
 POM_DESCRIPTION= An Android library to bring Material Design UI to pre-Lolipop Android.
 POM_URL=https://github.com/rey5137/Material
 POM_SCM_URL=https://github.com/rey5137/Material

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.1"
+    compileSdkVersion projectCompileSdkVersion
+    buildToolsVersion projectBuildToolsVersion
 
     defaultConfig {
-        minSdkVersion 9
-        targetSdkVersion 21
+        minSdkVersion projectMinSdkVersion
+        targetSdkVersion projectCompileSdkVersion
         versionCode 7
         versionName "1.2.1"
     }
@@ -20,8 +20,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:22.2.0'
-    compile 'com.android.support:cardview-v7:22.2.0'
+    compile 'com.android.support:appcompat-v7:23.1.1'
+    compile 'com.android.support:cardview-v7:23.1.1'
 }
-
-apply from: 'https://raw.github.com/chrisbanes/gradle-mvn-push/master/gradle-mvn-push.gradle'

--- a/lib/src/main/java/com/rey/material/drawable/ContactChipDrawable.java
+++ b/lib/src/main/java/com/rey/material/drawable/ContactChipDrawable.java
@@ -16,7 +16,6 @@ import android.text.BoringLayout;
 import android.text.Layout;
 import android.text.TextPaint;
 import android.text.TextUtils;
-import android.util.FloatMath;
 
 /**
  * Created by Rey on 1/21/2015.
@@ -89,7 +88,7 @@ public class ContactChipDrawable extends Drawable{
             return;
 
         int outerWidth = Math.max(0, bounds.width() - bounds.height() - mPaddingLeft - mPaddingRight);
-        mMetrics.width = (int) FloatMath.ceil(mTextPaint.measureText(mContactName, 0, mContactName.length()));
+        mMetrics.width = (int) Math.ceil(mTextPaint.measureText(mContactName, 0, mContactName.length()));
 
         if(mBoringLayout == null)
             mBoringLayout = BoringLayout.make(mContactName, mTextPaint, outerWidth, Layout.Alignment.ALIGN_NORMAL, 1f, 1f, mMetrics, true, TextUtils.TruncateAt.END, outerWidth);

--- a/lib/src/main/java/com/rey/material/text/style/ContactChipSpan.java
+++ b/lib/src/main/java/com/rey/material/text/style/ContactChipSpan.java
@@ -14,7 +14,6 @@ import android.text.StaticLayout;
 import android.text.TextPaint;
 import android.text.TextUtils;
 import android.text.style.ReplacementSpan;
-import android.util.FloatMath;
 
 /**
  * Created by Rey on 1/21/2015.
@@ -61,7 +60,7 @@ public class ContactChipSpan extends ReplacementSpan {
         int outerWidth = Math.max(0, mWidth - mPaddingLeft - mPaddingRight - mHeight);
         Paint.FontMetricsInt temp = mTextPaint.getFontMetricsInt();
         BoringLayout.Metrics mMetrics = new BoringLayout.Metrics();
-        mMetrics.width = (int)FloatMath.ceil(mTextPaint.measureText(mContactName, 0, mContactName.length()));
+        mMetrics.width = (int)Math.ceil(mTextPaint.measureText(mContactName, 0, mContactName.length()));
         mMetrics.ascent = temp.ascent;
         mMetrics.bottom = temp.bottom;
         mMetrics.descent = temp.descent;

--- a/lib/src/main/java/com/rey/material/util/ThemeUtil.java
+++ b/lib/src/main/java/com/rey/material/util/ThemeUtil.java
@@ -5,7 +5,7 @@ import android.content.Context;
 import android.content.res.Resources.Theme;
 import android.content.res.TypedArray;
 import android.os.Build;
-import android.support.v7.internal.widget.TintTypedArray;
+import android.support.v7.widget.TintTypedArray;
 import android.util.TypedValue;
 
 import com.rey.material.R;

--- a/lib/src/main/java/com/rey/material/widget/ListView.java
+++ b/lib/src/main/java/com/rey/material/widget/ListView.java
@@ -1,16 +1,17 @@
 package com.rey.material.widget;
 
 import android.content.Context;
-import android.support.v7.internal.widget.ListViewCompat;
+import android.support.v7.widget.ListViewCompat;
 import android.util.AttributeSet;
 import android.view.View;
+import android.widget.AbsListView;
 
 import com.rey.material.app.ThemeManager;
 import com.rey.material.util.ViewUtil;
 
 public class ListView extends ListViewCompat implements ThemeManager.OnThemeChangedListener{
 
-	private RecyclerListener mRecyclerListener;
+	private AbsListView.RecyclerListener mRecyclerListener;
 
     protected int mStyleId;
     protected int mCurrentStyle = ThemeManager.THEME_UNDEFINED;

--- a/lib/src/main/java/com/rey/material/widget/Spinner.java
+++ b/lib/src/main/java/com/rey/material/widget/Spinner.java
@@ -11,9 +11,9 @@ import android.os.Build;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
-import android.support.v7.internal.widget.TintManager;
-import android.support.v7.internal.widget.TintTypedArray;
-import android.support.v7.internal.widget.ViewUtils;
+import android.support.v7.widget.TintManager;
+import android.support.v7.widget.TintTypedArray;
+import android.support.v7.widget.ViewUtils;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.util.SparseArray;
@@ -233,6 +233,10 @@ public class Spinner extends FrameLayout implements ThemeManager.OnThemeChangedL
                 getLabelView().setText(a.getString(attr));
             else if(attr == R.styleable.Spinner_android_gravity)
                 mGravity = a.getInt(attr, 0);
+            else if (attr == R.styleable.Spinner_android_prompt)
+                mPopup.setPromptText(a.getString(attr));
+            else if (attr == R.styleable.Spinner_android_disableChildrenWhenDisabled)
+                mDisableChildrenWhenDisabled = a.getBoolean(attr, false);
             else if(attr == R.styleable.Spinner_android_minWidth)
                 setMinimumWidth(a.getDimensionPixelOffset(attr, 0));
             else if(attr == R.styleable.Spinner_android_minHeight)
@@ -241,14 +245,10 @@ public class Spinner extends FrameLayout implements ThemeManager.OnThemeChangedL
                 mDropDownWidth = a.getLayoutDimension(attr, LayoutParams.WRAP_CONTENT);
             else if(attr == R.styleable.Spinner_android_popupBackground)
                 mPopup.setBackgroundDrawable(a.getDrawable(attr));
-            else if(attr == R.styleable.Spinner_prompt)
-                mPopup.setPromptText(a.getString(attr));
             else if(attr == R.styleable.Spinner_spn_popupItemAnimation)
                 mPopup.setItemAnimation(a.getResourceId(attr, 0));
             else if(attr == R.styleable.Spinner_spn_popupItemAnimOffset)
                 mPopup.setItemAnimationOffset(a.getInteger(attr, 0));
-            else if(attr == R.styleable.Spinner_disableChildrenWhenDisabled)
-                mDisableChildrenWhenDisabled = a.getBoolean(attr, false);
             else if(attr == R.styleable.Spinner_spn_arrowSwitchMode)
                 mArrowAnimSwitchMode = a.getBoolean(attr, false);
             else if(attr == R.styleable.Spinner_spn_arrowAnimDuration)

--- a/lib/src/main/res/values/attrs.xml
+++ b/lib/src/main/res/values/attrs.xml
@@ -457,6 +457,8 @@
         <attr name="android:popupBackground" />
         <attr name="android:minWidth"/>
         <attr name="android:minHeight"/>
+        <attr name="android:gravity"/>
+        <attr name="android:disableChildrenWhenDisabled"/>
         <attr name="spn_labelEnable" format="boolean"/>
         <attr name="spn_labelPadding" format="reference|dimension"/>
         <attr name="spn_labelTextSize" format="reference|dimension"/>


### PR DESCRIPTION
- android.support.v7.internal.* was moved to android.support.v7.*
- now it's necessary to explicit attrs for `android:prompt` and `android:disableChildrenWhenDisabled`
- improve gradle build system with shared `compile target` and `build tools` values