### PR TITLE
Fixed button click being triggered during ripple animation

### DIFF
--- a/material/src/main/java/com/rey/material/widget/RippleManager.java
+++ b/material/src/main/java/com/rey/material/widget/RippleManager.java
@@ -82,10 +82,12 @@ public final class RippleManager implements View.OnClickListener{
 				delay = ((ToolbarRippleDrawable) background).getClickDelayTime();
 		}
 			
-		if(delay > 0 && v.getHandler() != null && !mClickScheduled) {
-            mClickScheduled = true;
-            v.getHandler().postDelayed(new ClickRunnable(v), delay);
-        }
+		if(delay > 0 && v.getHandler() != null) {
+			if(!mClickScheduled){
+            			mClickScheduled = true;
+            			v.getHandler().postDelayed(new ClickRunnable(v), delay);
+			}
+        	}
 		else
 			dispatchClickEvent(v);
 	}


### PR DESCRIPTION
As mentioned in issue #146 and pull request #147 multiple click events are being fired during click events.
The committed solution does not fix this issue since if the mClickScheduled flag is set to true, the button click will be triggered immediately instead of ignored.
