### PR TITLE
Fix 

### DIFF
--- a/app/src/main/res/values/styles_dark.xml
+++ b/app/src/main/res/values/styles_dark.xml
@@ -188,7 +188,7 @@
         <item name="spn_arrowAnimDuration">@android:integer/config_shortAnimTime</item>
         <item name="spn_arrowInterpolator">@android:anim/decelerate_interpolator</item>
         <item name="spn_arrowColor">@color/colorAccent</item>
-        <item name="android:popupBackground">@drawable/popup_background_dark</item>
+        <item name="spn_popupBackground">@drawable/popup_background_dark</item>
     </style>
 
     <style name="DarkSpinnerNoArrow" parent="DarkSpinner">

--- a/app/src/main/res/values/styles_light.xml
+++ b/app/src/main/res/values/styles_light.xml
@@ -186,7 +186,7 @@
         <item name="spn_arrowAnimDuration">@android:integer/config_shortAnimTime</item>
         <item name="spn_arrowInterpolator">@android:anim/decelerate_interpolator</item>
         <item name="spn_arrowColor">@color/colorControlNormal</item>
-        <item name="android:popupBackground">@drawable/abc_popup_background_mtrl_mult</item>
+        <item name="spn_popupBackground">@drawable/abc_popup_background_mtrl_mult</item>
     </style>
 
     <style name="LightSpinnerNoArrow" parent="LightSpinner">

--- a/material/src/main/java/com/rey/material/util/ViewUtil.java
+++ b/material/src/main/java/com/rey/material/util/ViewUtil.java
@@ -358,44 +358,44 @@ public class ViewUtil {
                 if (attr == R.styleable.TextAppearance_android_textColorHighlight) {
                     v.setHighlightColor(appearance.getColor(attr, 0));
 
-                } else if (attr == R.styleable.TextAppearance_android_textColor) {
+                } else if (attr == R.styleable.TextAppearance_ta_textColor) {
                     v.setTextColor(appearance.getColorStateList(attr));
 
-                } else if (attr == R.styleable.TextAppearance_android_textColorHint) {
+                } else if (attr == R.styleable.TextAppearance_ta_textColorHint) {
                     v.setHintTextColor(appearance.getColorStateList(attr));
 
-                } else if (attr == R.styleable.TextAppearance_android_textColorLink) {
+                } else if (attr == R.styleable.TextAppearance_ta_textColorLink) {
                     v.setLinkTextColor(appearance.getColorStateList(attr));
 
-                } else if (attr == R.styleable.TextAppearance_android_textSize) {
+                } else if (attr == R.styleable.TextAppearance_ta_textSize) {
                     v.setTextSize(TypedValue.COMPLEX_UNIT_PX, appearance.getDimensionPixelSize(attr, 0));
 
-                } else if (attr == R.styleable.TextAppearance_android_typeface) {
+                } else if (attr == R.styleable.TextAppearance_ta_typeface) {
                     typefaceIndex = appearance.getInt(attr, -1);
 
-                } else if (attr == R.styleable.TextAppearance_android_fontFamily) {
+                } else if (attr == R.styleable.TextAppearance_ta_fontFamily) {
                     fontFamily = appearance.getString(attr);
 
                 } else if (attr == R.styleable.TextAppearance_tv_fontFamily) {
                     fontFamily = appearance.getString(attr);
 
-                } else if (attr == R.styleable.TextAppearance_android_textStyle) {
+                } else if (attr == R.styleable.TextAppearance_ta_textStyle) {
                     styleIndex = appearance.getInt(attr, -1);
 
                 } else if (attr == R.styleable.TextAppearance_android_textAllCaps) {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH)
                         v.setAllCaps(appearance.getBoolean(attr, false));
 
-                } else if (attr == R.styleable.TextAppearance_android_shadowColor) {
+                } else if (attr == R.styleable.TextAppearance_ta_shadowColor) {
                     shadowColor = appearance.getInt(attr, 0);
 
-                } else if (attr == R.styleable.TextAppearance_android_shadowDx) {
+                } else if (attr == R.styleable.TextAppearance_ta_shadowDx) {
                     dx = appearance.getFloat(attr, 0);
 
-                } else if (attr == R.styleable.TextAppearance_android_shadowDy) {
+                } else if (attr == R.styleable.TextAppearance_ta_shadowDy) {
                     dy = appearance.getFloat(attr, 0);
 
-                } else if (attr == R.styleable.TextAppearance_android_shadowRadius) {
+                } else if (attr == R.styleable.TextAppearance_ta_shadowRadius) {
                     r = appearance.getFloat(attr, 0);
 
                 } else if (attr == R.styleable.TextAppearance_android_elegantTextHeight) {
@@ -482,44 +482,44 @@ public class ViewUtil {
                 if (attr == R.styleable.TextAppearance_android_textColorHighlight) {
                     v.setHighlightColor(appearance.getColor(attr, 0));
 
-                } else if (attr == R.styleable.TextAppearance_android_textColor) {
+                } else if (attr == R.styleable.TextAppearance_ta_textColor) {
                     v.setTextColor(appearance.getColorStateList(attr));
 
-                } else if (attr == R.styleable.TextAppearance_android_textColorHint) {
+                } else if (attr == R.styleable.TextAppearance_ta_textColorHint) {
                     v.setHintTextColor(appearance.getColorStateList(attr));
 
-                } else if (attr == R.styleable.TextAppearance_android_textColorLink) {
+                } else if (attr == R.styleable.TextAppearance_ta_textColorLink) {
                     v.setLinkTextColor(appearance.getColorStateList(attr));
 
-                } else if (attr == R.styleable.TextAppearance_android_textSize) {
+                } else if (attr == R.styleable.TextAppearance_ta_textSize) {
                     v.setTextSize(TypedValue.COMPLEX_UNIT_PX, appearance.getDimensionPixelSize(attr, 0));
 
-                } else if (attr == R.styleable.TextAppearance_android_typeface) {
+                } else if (attr == R.styleable.TextAppearance_ta_typeface) {
                     typefaceIndex = appearance.getInt(attr, -1);
 
-                } else if (attr == R.styleable.TextAppearance_android_fontFamily) {
+                } else if (attr == R.styleable.TextAppearance_ta_fontFamily) {
                     fontFamily = appearance.getString(attr);
 
                 } else if (attr == R.styleable.TextAppearance_tv_fontFamily) {
                     fontFamily = appearance.getString(attr);
 
-                } else if (attr == R.styleable.TextAppearance_android_textStyle) {
+                } else if (attr == R.styleable.TextAppearance_ta_textStyle) {
                     styleIndex = appearance.getInt(attr, -1);
 
                 } else if (attr == R.styleable.TextAppearance_android_textAllCaps) {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH)
                         v.setAllCaps(appearance.getBoolean(attr, false));
 
-                } else if (attr == R.styleable.TextAppearance_android_shadowColor) {
+                } else if (attr == R.styleable.TextAppearance_ta_shadowColor) {
                     shadowColor = appearance.getInt(attr, 0);
 
-                } else if (attr == R.styleable.TextAppearance_android_shadowDx) {
+                } else if (attr == R.styleable.TextAppearance_ta_shadowDx) {
                     dx = appearance.getFloat(attr, 0);
 
-                } else if (attr == R.styleable.TextAppearance_android_shadowDy) {
+                } else if (attr == R.styleable.TextAppearance_ta_shadowDy) {
                     dy = appearance.getFloat(attr, 0);
 
-                } else if (attr == R.styleable.TextAppearance_android_shadowRadius) {
+                } else if (attr == R.styleable.TextAppearance_ta_shadowRadius) {
                     r = appearance.getFloat(attr, 0);
 
                 } else if (attr == R.styleable.TextAppearance_android_elegantTextHeight) {

--- a/material/src/main/java/com/rey/material/widget/Spinner.java
+++ b/material/src/main/java/com/rey/material/widget/Spinner.java
@@ -216,11 +216,11 @@ public class Spinner extends FrameLayout implements ThemeManager.OnThemeChangedL
                 setMinimumWidth(a.getDimensionPixelOffset(attr, 0));
             else if(attr == R.styleable.Spinner_android_minHeight)
                 setMinimumHeight(a.getDimensionPixelOffset(attr, 0));
-            else if(attr == R.styleable.Spinner_android_dropDownWidth)
+            else if(attr == R.styleable.Spinner_spn_dropDownWidth)
                 mDropDownWidth = a.getLayoutDimension(attr, LayoutParams.WRAP_CONTENT);
-            else if(attr == R.styleable.Spinner_android_popupBackground)
+            else if(attr == R.styleable.Spinner_spn_popupBackground)
                 mPopup.setBackgroundDrawable(a.getDrawable(attr));
-            else if(attr == R.styleable.Spinner_android_prompt)
+            else if(attr == R.styleable.Spinner_spn_prompt)
                 mPopup.setPromptText(a.getString(attr));
             else if(attr == R.styleable.Spinner_spn_popupItemAnimation)
                 mPopup.setItemAnimation(a.getResourceId(attr, 0));
@@ -434,7 +434,7 @@ public class Spinner extends FrameLayout implements ThemeManager.OnThemeChangedL
      *
      * @param background Background drawable
      *
-     * @attr ref android.R.styleable#Spinner_popupBackground
+     * @attr ref android.R.styleable#Spinner_spn_popupBackground
      */
     public void setPopupBackgroundDrawable(Drawable background) {
     	mPopup.setBackgroundDrawable(background);
@@ -445,7 +445,7 @@ public class Spinner extends FrameLayout implements ThemeManager.OnThemeChangedL
      *
      * @param resId Resource ID of a background drawable
      *
-     * @attr ref android.R.styleable#Spinner_popupBackground
+     * @attr ref android.R.styleable#Spinner_spn_popupBackground
      */
     public void setPopupBackgroundResource(int resId) {
         setPopupBackgroundDrawable(getContext().getDrawable(resId));
@@ -456,7 +456,7 @@ public class Spinner extends FrameLayout implements ThemeManager.OnThemeChangedL
      *
      * @return background Background drawable
      *
-     * @attr ref android.R.styleable#Spinner_popupBackground
+     * @attr ref android.R.styleable#Spinner_spn_popupBackground
      */
     public Drawable getPopupBackground() {
         return mPopup.getBackground();
@@ -515,7 +515,7 @@ public class Spinner extends FrameLayout implements ThemeManager.OnThemeChangedL
      *
      * @param pixels Width in pixels, WRAP_CONTENT, or MATCH_PARENT
      *
-     * @attr ref android.R.styleable#Spinner_dropDownWidth
+     * @attr ref android.R.styleable#Spinner_spn_dropDownWidth
      */
     public void setDropDownWidth(int pixels) {
         mDropDownWidth = pixels;
@@ -530,7 +530,7 @@ public class Spinner extends FrameLayout implements ThemeManager.OnThemeChangedL
      *
      * @return Width in pixels, WRAP_CONTENT, or MATCH_PARENT
      *
-     * @attr ref android.R.styleable#Spinner_dropDownWidth
+     * @attr ref android.R.styleable#Spinner_spn_dropDownWidth
      */
     public int getDropDownWidth() {
         return mDropDownWidth;

--- a/material/src/main/res/values/attrs.xml
+++ b/material/src/main/res/values/attrs.xml
@@ -98,19 +98,24 @@
 
     <declare-styleable name="TextAppearance">
         <attr name="android:textColorHighlight" />
-        <attr name="android:textColor" />
-        <attr name="android:textColorHint" />
-        <attr name="android:textColorLink" />
-        <attr name="android:textSize" />
-        <attr name="android:textStyle" />
-        <attr name="android:typeface" />
-        <attr name="android:fontFamily" />
+        <attr name="ta_textColor" format="reference|color" />
+        <attr name="ta_textColorHint" format="string|reference" />
+        <attr name="ta_textColorLink" format="string|reference" />
+        <attr name="ta_textSize" format="reference|dimension"/>
+        <attr name="ta_textStyle" format="integer">
+            <enum name="normal" value="0" />
+            <enum name="bold" value="1" />
+            <enum name="italic" value="2" />
+            <enum name="bold_italic" value="3" />
+        </attr>
+        <attr name="ta_typeface" format="string|reference" />
+        <attr name="ta_fontFamily" format="string|reference" />
         <attr name="tv_fontFamily" />
         <attr name="android:textAllCaps" />
-        <attr name="android:shadowColor" />
-        <attr name="android:shadowDx" />
-        <attr name="android:shadowDy" />
-        <attr name="android:shadowRadius" />
+        <attr name="ta_shadowColor" format="reference|color"/>
+        <attr name="ta_shadowDx" format="reference|integer"/>
+        <attr name="ta_shadowDy" format="reference|integer"/>
+        <attr name="ta_shadowRadius" format="reference|integer"/>
         <attr name="android:elegantTextHeight" />
         <attr name="android:fontFeatureSettings" />
         <attr name="android:letterSpacing" />
@@ -462,9 +467,9 @@
     
     <declare-styleable name="Spinner">
         <attr name="android:gravity" />
-        <attr name="android:prompt" />
-        <attr name="android:dropDownWidth" /> 
-        <attr name="android:popupBackground" />
+        <attr name="spn_prompt" format="string|reference"/>
+        <attr name="spn_dropDownWidth" format="reference|dimension"/>
+        <attr name="spn_popupBackground" format="reference"/>
         <attr name="android:minWidth"/>
         <attr name="android:minHeight"/>
         <attr name="spn_disableChildrenWhenDisabled" format="boolean"/>


### PR DESCRIPTION
When I'm trying to bind the material `.aar` library with `Xamarin.Android`, tooling raises an error:

```
../obj/Debug/android/src/com/rey/material/R.java(27,27): Error JAVAC0000:  error: variable Spinner_android_dropDownWidth is already defined in class styleable
public static final int Spinner_android_dropDownWidth = 6;
```

After a quick research, I figured out that the `rey5137/material` defines styleable attributes with reserved by Android SDK names. You can see it by hovering that attribute. And while this is just a warning in Android Studio, it's a blocker error in Xamarin.Android and I'm unable to bind this library:

<img width="1231" alt="Screenshot 2019-10-08 22 24 35" src="https://user-images.githubusercontent.com/3697084/66457120-6a05d480-ea24-11e9-8240-e53f9e6d18e5.png">

I'm not very familiar with styleable attributes but after [some reading](https://medium.com/@elye.project/better-way-of-declaring-custom-view-attributes-23f876c28534) it seems that we want to define new attributes with unique names and move the rest into a common section to avoid duplicates. In our case, we also don't want to use reserved attributes names. The following 11 attributes were renamed to avoid that conflict:

1. Spinner_android_dropDownWidth
2. Spinner_android_popupBackground
3. Spinner_android_prompt
4. TextAppearance_android_textColor
5. TextAppearance_android_textColorHint
6. TextAppearance_android_textColorLink
7. TextAppearance_android_textSize
8. TextAppearance_android_typeface
9. TextAppearance_android_fontFamily
10. TextAppearance_android_textStyle
11. TextAppearance_android_shadowColor
12. TextAppearance_android_shadowDx
13. TextAppearance_android_shadowDy
14. TextAppearance_android_shadowRadius