### PR TITLE
FIX: Failed to resolve: com.github.rey5137:material:1.3.0 

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,16 @@ Add Gradle dependency:
 dependencies {
    implementation 'com.github.rey5137:material:1.2.4'
 }
+``` 
+
+Under Project Level build.gradle, Add:     
+
+```
+allprojects {
+    repositories {
+        maven { url 'https://jitpack.io' }    // Add This Line
+    }
+}
 ```
 
 * Or


### PR DESCRIPTION
Many users were facing this issue: `Failed to resolve: com.github.rey5137:material:1.3.0`

They seemed to have no problem with the version `1.2.5` but apparently the version `1.3.0` had this issue.

This can be solved by adding :
```
allprojects {
    repositories {
        maven { url 'https://jitpack.io' }    // Add This Line
    }
}
```  

I've updated the README file for the same.